### PR TITLE
Depend on less recent base in Snake.cabal

### DIFF
--- a/Snake.cabal
+++ b/Snake.cabal
@@ -9,5 +9,5 @@ Synopsis:      Simple and short implementation of a Snake game. Any pull request
 Build-type:    Simple
 
 Library
-  Build-Depends: base >= 4.7,
+  Build-Depends: base >= 4.6.0.1,
                  monad-loops >= 0.4.2.1


### PR DESCRIPTION
This allows a cabal sandbox build on Ubuntu 14.04 with the current haskell-package GHC (7.6.3).
